### PR TITLE
Fix default export resolution issue

### DIFF
--- a/supabase/functions/_shared/cache.index.ts
+++ b/supabase/functions/_shared/cache.index.ts
@@ -1,1 +1,7 @@
-export * from "./cache";
+import { Cache, cache } from "./cache";
+
+export { Cache, cache };
+export default {
+  Cache,
+  cache,
+};

--- a/supabase/functions/_shared/cors.index.ts
+++ b/supabase/functions/_shared/cors.index.ts
@@ -1,19 +1,10 @@
 // Export all named exports from cors module
-export const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers":
-    "authorization, x-client-info, apikey, content-type",
+import { corsHeaders, setCorsHeaders, handleCors } from "./cors";
+
+export { corsHeaders, setCorsHeaders, handleCors };
+
+export default {
+  corsHeaders,
+  setCorsHeaders,
+  handleCors,
 };
-
-export function setCorsHeaders(headers: Headers): void {
-  Object.entries(corsHeaders).forEach(([key, value]) => {
-    headers.set(key, value);
-  });
-}
-
-export function handleCors(req: Request): Response | null {
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
-  return null;
-}

--- a/supabase/functions/_shared/index.ts
+++ b/supabase/functions/_shared/index.ts
@@ -1,12 +1,51 @@
 // Main index file for shared modules
 // Export all named exports from each module
-export * from "./cors.index";
-export * from "./error-handler.index";
-export * from "./stripe-types.index";
-export * from "./validation.index";
-export * from "./cache.index";
-export * from "./stripe-config.index";
-export * from "./types.index";
+export { corsHeaders, setCorsHeaders, handleCors } from "./cors.index";
+export {
+  ApiError,
+  ErrorResponse,
+  handleError,
+  handleValidationError,
+  handleNotFoundError,
+  handleAuthError,
+} from "./error-handler.index";
+export type {
+  StripeWebhookEvent,
+  StripePaymentIntent,
+  StripeSubscription,
+  PaymentIntentCreateParams,
+  PaymentIntentConfirmParams,
+  SubscriptionCreateParams,
+} from "./stripe-types.index";
+export { validateRequiredFields } from "./validation.index";
+export { Cache, cache } from "./cache.index";
+export {
+  stripeConfig,
+  validateStripeConfig,
+  validateWebhookConfig,
+  handleStripeCorsRequest,
+  stripe,
+} from "./stripe-config.index";
+export type {
+  PaginationParams,
+  SortParams,
+  FilterParams,
+  ApiResponse,
+  PaginatedResponse,
+} from "./types.index";
 
-// Do not use default export to avoid the SyntaxError
-// with "Importing binding name 'default' cannot be resolved by star export entries"
+import * as cors from "./cors.index";
+import * as errorHandler from "./error-handler.index";
+import * as validation from "./validation.index";
+import * as cacheModule from "./cache.index";
+import * as stripeConfigModule from "./stripe-config.index";
+
+const shared = {
+  ...cors,
+  ...errorHandler,
+  ...validation,
+  ...cacheModule,
+  ...stripeConfigModule,
+};
+
+export default shared;

--- a/supabase/functions/_shared/stripe-config.index.ts
+++ b/supabase/functions/_shared/stripe-config.index.ts
@@ -1,1 +1,23 @@
-export * from "./stripe-config";
+import {
+  stripeConfig,
+  validateStripeConfig,
+  validateWebhookConfig,
+  handleStripeCorsRequest,
+  stripe,
+} from "./stripe-config";
+
+export {
+  stripeConfig,
+  validateStripeConfig,
+  validateWebhookConfig,
+  handleStripeCorsRequest,
+  stripe,
+};
+
+export default {
+  stripeConfig,
+  validateStripeConfig,
+  validateWebhookConfig,
+  handleStripeCorsRequest,
+  stripe,
+};

--- a/supabase/functions/_shared/types.index.ts
+++ b/supabase/functions/_shared/types.index.ts
@@ -1,1 +1,7 @@
-export * from "./types";
+export type {
+  PaginationParams,
+  SortParams,
+  FilterParams,
+  ApiResponse,
+  PaginatedResponse,
+} from "./types";


### PR DESCRIPTION
## Summary
- refactor shared module exports so they no longer use `export *`
- explicitly list exports in each shared index and provide default aggregates

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*