### PR TITLE
Enhance ESG utilities and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,11 @@ The production container listens on port `8080` by default.
 
 The `.do/app.yaml` file defines the App Platform specification. Commit any changes
 to this file and push to trigger a deployment.
+
+### Running Tests
+
+Unit tests are powered by [Vitest](https://vitest.dev). Execute the test suite with:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc ; vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
+    "test": "vitest",
     "types:supabase": "npx supabase gen types typescript --project-id spmqzflhdlatsfkkylwq > src/types/supabase.ts",
     "start": "serve -s dist -l ${PORT:-3000}",
     "dev:debug": "node --inspect=0.0.0.0:9229 ./node_modules/vite/bin/vite.js --host 0.0.0.0 --port 3000"
@@ -96,6 +97,7 @@
     "tailwindcss": "3.4.1",
     "tempo-devtools": "^2.0.105",
     "typescript": "^5.8.2",
-    "vite": "^5.2.8"
+    "vite": "^5.2.8",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/lib/ai-services.ts
+++ b/src/lib/ai-services.ts
@@ -1,5 +1,6 @@
 import { supabase } from "./supabase";
 import { logger } from "./logger";
+import { measureAsync } from "./performance-utils";
 
 export interface AIAssistantResponse {
   content: string;
@@ -26,20 +27,21 @@ export async function getFrameworkRecommendations(
   materialityTopics: Record<string, unknown>[] = [],
 ): Promise<AIAssistantResponse> {
   try {
-    const { data, error } = await supabase.functions.invoke(
-      "supabase-functions-esg-ai-assistant",
-      {
-        body: {
-          prompt:
-            "Provide ESG framework recommendations based on the company profile and materiality topics. Include specific indicators from GRI, SASB, TCFD, and UN SDGs that are most relevant.",
-          context: {
-            companyProfile,
-            materialityTopics,
+    const { data, error } = await measureAsync(
+      "getFrameworkRecommendations",
+      () =>
+        supabase.functions.invoke("supabase-functions-esg-ai-assistant", {
+          body: {
+            prompt:
+              "Provide ESG framework recommendations based on the company profile and materiality topics. Include specific indicators from GRI, SASB, TCFD, and UN SDGs that are most relevant.",
+            context: {
+              companyProfile,
+              materialityTopics,
+            },
+            task: "framework-mapping",
+            maxTokens: 800,
           },
-          task: "framework-mapping",
-          maxTokens: 800,
-        },
-      },
+        }),
     );
 
     if (error) throw error;
@@ -65,21 +67,22 @@ export async function getResourceRecommendations(
   materialityTopics: Record<string, unknown>[] = [],
 ): Promise<AIAssistantResponse> {
   try {
-    const { data, error } = await supabase.functions.invoke(
-      "supabase-functions-esg-ai-assistant",
-      {
-        body: {
-          prompt:
-            "Recommend resources from the library that would help implement this ESG plan effectively, with special focus on the high-priority materiality topics.",
-          context: {
-            esgPlan,
-            companyProfile,
-            materialityTopics,
+    const { data, error } = await measureAsync(
+      "getResourceRecommendations",
+      () =>
+        supabase.functions.invoke("supabase-functions-esg-ai-assistant", {
+          body: {
+            prompt:
+              "Recommend resources from the library that would help implement this ESG plan effectively, with special focus on the high-priority materiality topics.",
+            context: {
+              esgPlan,
+              companyProfile,
+              materialityTopics,
+            },
+            task: "resource-recommendation",
+            maxTokens: 600,
           },
-          task: "resource-recommendation",
-          maxTokens: 600,
-        },
-      },
+        }),
     );
 
     if (error) throw error;

--- a/src/lib/esg-data-services.index.ts
+++ b/src/lib/esg-data-services.index.ts
@@ -3,6 +3,7 @@ import {
   ESGHistoricalDataPoint, // Interface
   ESGDataPoint, // Interface
   ESGFrameworkMapping, // Interface
+  ESGFramework,
   PaginationParams, // Interface
   PaginatedResponse, // Interface
   getESGDataPoints,
@@ -14,6 +15,7 @@ import {
   deleteESGFrameworkMapping,
   getUserESGDataPoints,
   searchESGDataPoints,
+  getFrameworks,
   getFrameworkRecommendations, // Original name from esg-data-services.ts
   getFrameworkMappings, // Original name from esg-data-services.ts
 } from "./esg-data-services";
@@ -22,6 +24,7 @@ export type {
   ESGHistoricalDataPoint,
   ESGDataPoint,
   ESGFrameworkMapping,
+  ESGFramework,
   PaginationParams,
   PaginatedResponse,
 };
@@ -36,6 +39,7 @@ export {
   deleteESGFrameworkMapping,
   getUserESGDataPoints,
   searchESGDataPoints,
+  getFrameworks,
   getFrameworkRecommendations,
   getFrameworkMappings,
 };
@@ -51,6 +55,7 @@ export default {
   deleteESGFrameworkMapping,
   getUserESGDataPoints,
   searchESGDataPoints,
+  getFrameworks,
   getFrameworkRecommendations,
   getFrameworkMappings,
 };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -51,6 +51,7 @@ import {
   deleteESGFrameworkMapping,
   getUserESGDataPoints,
   searchESGDataPoints,
+  getFrameworks,
   getFrameworkRecommendations as getMetricFrameworkRecommendations,
   getFrameworkMappings as getFrameworkMappingsByFrameworkId,
 } from "./esg-data-services";
@@ -122,6 +123,7 @@ export {
   deleteESGFrameworkMapping,
   getUserESGDataPoints,
   searchESGDataPoints,
+  getFrameworks,
   getMetricFrameworkRecommendations,
   getFrameworkMappingsByFrameworkId,
 };
@@ -183,6 +185,7 @@ import {
   deleteESGFrameworkMapping as deleteESGFrameworkMapping_esg,
   getUserESGDataPoints as getUserESGDataPoints_esg,
   searchESGDataPoints as searchESGDataPoints_esg,
+  getFrameworks as getFrameworks_esg,
   getFrameworkRecommendations as getMetricFrameworkRecommendations_esg, // Aliased from esg-data-services
   getFrameworkMappings as getFrameworkMappingsByFrameworkId_esg, // Aliased from esg-data-services
 } from "./esg-data-services";
@@ -234,6 +237,7 @@ const libExports = {
   deleteESGFrameworkMapping: deleteESGFrameworkMapping_esg,
   getUserESGDataPoints: getUserESGDataPoints_esg,
   searchESGDataPoints: searchESGDataPoints_esg,
+  getFrameworks: getFrameworks_esg,
   getMetricFrameworkRecommendations: getMetricFrameworkRecommendations_esg,
   getFrameworkMappingsByFrameworkId: getFrameworkMappingsByFrameworkId_esg,
   getTailoredRecommendations: getTailoredRecommendations_tailored,

--- a/src/lib/performance-utils.ts
+++ b/src/lib/performance-utils.ts
@@ -1,0 +1,9 @@
+export async function measureAsync<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  const timerLabel = `perf:${label}`;
+  console.time(timerLabel);
+  try {
+    return await fn();
+  } finally {
+    console.timeEnd(timerLabel);
+  }
+}

--- a/tests/ai-services.test.ts
+++ b/tests/ai-services.test.ts
@@ -1,0 +1,20 @@
+import { vi, describe, it, expect } from 'vitest';
+import { getFrameworkRecommendations } from '../src/lib/ai-services';
+
+vi.mock('../src/lib/supabase', () => {
+  return {
+    supabase: {
+      functions: {
+        invoke: vi.fn(() => Promise.resolve({ data: { content: 'ok' }, error: null }))
+      }
+    }
+  };
+});
+
+describe('getFrameworkRecommendations', () => {
+  it('calls supabase function and returns content', async () => {
+    const res = await getFrameworkRecommendations({}, []);
+    expect(res.success).toBe(true);
+    expect(res.content).toBe('ok');
+  });
+});

--- a/tests/esg-data-services.test.ts
+++ b/tests/esg-data-services.test.ts
@@ -1,0 +1,26 @@
+import { vi, describe, it, expect } from 'vitest';
+import { getESGDataPoints } from '../src/lib/esg-data-services';
+
+vi.mock('../src/lib/supabase', () => {
+  const from = vi.fn(() => ({
+    select: vi.fn((...args: any[]) => {
+      if (args[1]?.count) {
+        return { eq: vi.fn(() => Promise.resolve({ count: 1, error: null })) };
+      }
+      return {
+        eq: vi.fn(() => ({
+          range: vi.fn(() => Promise.resolve({ data: [{ id: '1', resource_id: 'r1', metric_id: 'm1', value: 'v' }], error: null }))
+        }))
+      };
+    })
+  }));
+  return { supabase: { from } };
+});
+
+describe('getESGDataPoints', () => {
+  it('returns data from supabase', async () => {
+    const result = await getESGDataPoints('r1', { page: 1, pageSize: 10 });
+    expect(result.data.length).toBe(1);
+    expect(result.count).toBe(1);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
       "@shared/*": ["supabase/functions/_shared/*"]
     }
   },
-  "include": ["src", "supabase/functions/_shared"], 
+  "include": ["src", "supabase/functions/_shared", "tests"],
   "exclude": [
     "node_modules",
     "dist",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- connect plan enhancement to ESG AI assistant
- add performance measurement helper
- fetch frameworks dynamically and use in dashboard
- improve ESG search ranking and filtering
- export new data service helpers
- wrap AI service calls with performance logging
- add Vitest config and basic unit tests
- document testing in README

## Testing
- `npx vitest run` *(fails: request to https://registry.npmjs.org/vitest failed)*