### PR TITLE
Fix build referencing Node tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,5 @@
     "node_modules",
     "dist",
     "src/tempobook"
-  ],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  ]
 }


### PR DESCRIPTION
## Summary
- remove unused reference to `tsconfig.node.json` from the main TS configuration

## Testing
- `npm run lint` *(fails: missing eslint plugin)*
- `npm ci --ignore-scripts` *(fails: npm error)*